### PR TITLE
Update: handling logic for alwayAllowPermission in iOS.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.cli.common.toBooleanLenient
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 val isSnapshotUpload = System.getProperty("snapshot").toBooleanLenient() ?: false
-val libVersion = "0.2.5"
+val libVersion = "0.2.6"
 val gitName = "abc-${project.name}"
 
 buildscript {

--- a/kmm_location.podspec
+++ b/kmm_location.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'kmm_location'
-    spec.version                  = '0.2.5'
+    spec.version                  = '0.2.6'
     spec.homepage                 = ''
     spec.source                   = { :git => "Not Published", :tag => "Cocoapods/#{spec.name}/#{spec.version}" }
     spec.authors                  = ''

--- a/sample/iosApp/iosApp/ViewController.swift
+++ b/sample/iosApp/iosApp/ViewController.swift
@@ -20,6 +20,9 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         ABCLocation.Companion().requiredPermission = .authorizedalways
+        ABCLocation.Companion().onAlwaysAllowsPermissionRequired(target: self) {
+            print("onAlwaysAllowsPermissionRequired")
+        }
     }
     
     @IBAction func tappedCurrent(_ sender: UIButton) {
@@ -28,7 +31,9 @@ class ViewController: UIViewController {
                 print("onLocationUnavailable")
                 showPermissionDeniedAlert()
             }
-            .onPermissionUpdated(target: <#T##Any#>, block: <#T##(KotlinBoolean) -> Void#>)
+            .onPermissionUpdated(target: self, block: {
+                print("onPermissionUpdated. Granted:", $0)
+            })
             .currentLocation { [unowned self] data in
                 print("location coordinates", Date(), data.coordinates)
                 locationLabel.text = "Single \(data.coordinates.latitude)\n\(locationLabel.text!)"
@@ -45,7 +50,6 @@ class ViewController: UIViewController {
                 print("location coordinates", Date(), data.coordinates)
                 locationLabel.text = "Continuous \(data.coordinates.latitude)\n\(locationLabel.text!)"
             }
-            .
             .startLocationUpdating()
     }
 

--- a/sample/shared/build.gradle.kts
+++ b/sample/shared/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     kotlin("native.cocoapods")
 }
 
-val abcLocationLib = "com.linecorp.abc:kmm-location:0.2.4"
+val abcLocationLib = "com.linecorp.abc:kmm-location:0.2.6"
 
 version = "1.0"
 

--- a/src/iosMain/kotlin/com/linecorp/abc/location/CLLocationManagerDelegate.kt
+++ b/src/iosMain/kotlin/com/linecorp/abc/location/CLLocationManagerDelegate.kt
@@ -1,5 +1,6 @@
 package com.linecorp.abc.location
 
+import com.linecorp.abc.location.extension.previousAuthorizationStatus
 import com.linecorp.abc.location.extension.requiredPermission
 import kotlinx.cinterop.useContents
 import platform.CoreLocation.*
@@ -25,6 +26,7 @@ internal class CLLocationManagerDelegate: NSObject(), CLLocationManagerDelegateP
         val isGranted = ABCLocation.requiredPermission == status ||
                 LocationAuthorizationStatus.AuthorizedAlways == status
         ABCLocation.notifyOnPermissionUpdated(isGranted)
+        ABCLocation.previousAuthorizationStatus = status
         ABCLocation.startLocationUpdating()
     }
 

--- a/src/iosMain/kotlin/com/linecorp/abc/location/LocationManager.kt
+++ b/src/iosMain/kotlin/com/linecorp/abc/location/LocationManager.kt
@@ -59,6 +59,7 @@ internal actual class LocationManager {
     // -------------------------------------------------------------------------------------------
 
     var requiredPermission = LocationAuthorizationStatus.AuthorizedAlways
+    var previousAuthorizationStatus = LocationAuthorizationStatus.NotSet
 
     fun onAlwaysAllowsPermissionRequired(
         target: Any,
@@ -99,8 +100,6 @@ internal actual class LocationManager {
     }
 
     private val onAlwaysAllowsPermissionRequiredBlockMap = NativeAtomicReference(mapOf<Any, OnAlwaysAllowsPermissionRequiredBlock>())
-
-    private var previousAuthorizationStatus = LocationAuthorizationStatus.NotSet
 
     private fun notifyOnAlwaysAllowsPermissionRequired() {
         onAlwaysAllowsPermissionRequiredBlockMap.value.forEach { it.value() }

--- a/src/iosMain/kotlin/com/linecorp/abc/location/extension/ABCLocationExt.kt
+++ b/src/iosMain/kotlin/com/linecorp/abc/location/extension/ABCLocationExt.kt
@@ -6,11 +6,6 @@ import com.linecorp.abc.location.LocationAuthorizationStatus
 
 typealias OnAlwaysAllowsPermissionRequiredBlock = () -> Unit
 
-
-internal var ABCLocation.Companion.previousAuthorizationStatus: LocationAuthorizationStatus
-    get() = locationManager.previousAuthorizationStatus
-    set(value) { locationManager.previousAuthorizationStatus = value }
-
 var ABCLocation.Companion.requiredPermission: LocationAuthorizationStatus
     get() = locationManager.requiredPermission
     set(value) { locationManager.requiredPermission = value }
@@ -25,3 +20,7 @@ fun ABCLocation.Companion.onAlwaysAllowsPermissionRequired(
 
 fun ABCLocation.Companion.removeOnAlwaysAllowsPermissionRequired(target: Any) =
     locationManager.removeOnAlwaysAllowsPermissionRequired(target)
+    
+internal var ABCLocation.Companion.previousAuthorizationStatus: LocationAuthorizationStatus
+    get() = locationManager.previousAuthorizationStatus
+    set(value) { locationManager.previousAuthorizationStatus = value }

--- a/src/iosMain/kotlin/com/linecorp/abc/location/extension/ABCLocationExt.kt
+++ b/src/iosMain/kotlin/com/linecorp/abc/location/extension/ABCLocationExt.kt
@@ -6,6 +6,11 @@ import com.linecorp.abc.location.LocationAuthorizationStatus
 
 typealias OnAlwaysAllowsPermissionRequiredBlock = () -> Unit
 
+
+var ABCLocation.Companion.previousAuthorizationStatus: LocationAuthorizationStatus
+    get() = locationManager.previousAuthorizationStatus
+    set(value) { locationManager.previousAuthorizationStatus = value }
+
 var ABCLocation.Companion.requiredPermission: LocationAuthorizationStatus
     get() = locationManager.requiredPermission
     set(value) { locationManager.requiredPermission = value }

--- a/src/iosMain/kotlin/com/linecorp/abc/location/extension/ABCLocationExt.kt
+++ b/src/iosMain/kotlin/com/linecorp/abc/location/extension/ABCLocationExt.kt
@@ -7,7 +7,7 @@ import com.linecorp.abc.location.LocationAuthorizationStatus
 typealias OnAlwaysAllowsPermissionRequiredBlock = () -> Unit
 
 
-var ABCLocation.Companion.previousAuthorizationStatus: LocationAuthorizationStatus
+internal var ABCLocation.Companion.previousAuthorizationStatus: LocationAuthorizationStatus
     get() = locationManager.previousAuthorizationStatus
     set(value) { locationManager.previousAuthorizationStatus = value }
 


### PR DESCRIPTION
`LocationManager.previousAuthorizationStatus` 값의 업데이트가 이루어지지 않아,
 AllwaysAllow Permission 권한 체크가 이루어지지 못한 문제를 수정합니다.

Ref: [ABC/SharedLocation.kt](https://git.linecorp.com/abc/shared-location-kmm/blob/develop/src/iosMain/kotlin/com/linecorp/abc/sharedlocation/SharedLocation.kt) 197 Line