### PR TITLE
Bugfix: ThrowInvalidMutabilityException in previousAuthorizationStatus.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.cli.common.toBooleanLenient
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 val isSnapshotUpload = System.getProperty("snapshot").toBooleanLenient() ?: false
-val libVersion = "0.2.7"
+val libVersion = "0.2.8"
 val gitName = "abc-${project.name}"
 
 buildscript {

--- a/kmm_location.podspec
+++ b/kmm_location.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'kmm_location'
-    spec.version                  = '0.2.7'
+    spec.version                  = '0.2.8'
     spec.homepage                 = ''
     spec.source                   = { :git => "Not Published", :tag => "Cocoapods/#{spec.name}/#{spec.version}" }
     spec.authors                  = ''

--- a/sample/shared/build.gradle.kts
+++ b/sample/shared/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     kotlin("native.cocoapods")
 }
 
-val abcLocationLib = "com.linecorp.abc:kmm-location:0.2.6"
+val abcLocationLib = "com.linecorp.abc:kmm-location:0.2.8"
 
 version = "1.0"
 

--- a/src/iosMain/kotlin/com/linecorp/abc/location/LocationManager.kt
+++ b/src/iosMain/kotlin/com/linecorp/abc/location/LocationManager.kt
@@ -59,7 +59,7 @@ internal actual class LocationManager {
     // -------------------------------------------------------------------------------------------
 
     var requiredPermission = LocationAuthorizationStatus.AuthorizedAlways
-    var previousAuthorizationStatus = NativeAtomicReference(LocationAuthorizationStatus.NotSet)
+    val previousAuthorizationStatus = NativeAtomicReference(LocationAuthorizationStatus.NotSet)
 
     fun onAlwaysAllowsPermissionRequired(
         target: Any,

--- a/src/iosMain/kotlin/com/linecorp/abc/location/LocationManager.kt
+++ b/src/iosMain/kotlin/com/linecorp/abc/location/LocationManager.kt
@@ -36,7 +36,7 @@ internal actual class LocationManager {
     actual fun startLocationUpdating() = when (authorizationStatus) {
         LocationAuthorizationStatus.AuthorizedAlways -> startUpdating()
         LocationAuthorizationStatus.AuthorizedWhenInUse -> if (isRequiredAllowAlways) {
-            if (previousAuthorizationStatus == LocationAuthorizationStatus.AuthorizedWhenInUse) {
+            if (previousAuthorizationStatus.value == LocationAuthorizationStatus.AuthorizedWhenInUse) {
                 notifyOnAlwaysAllowsPermissionRequired()
             } else {
                 requestPermission()
@@ -59,7 +59,7 @@ internal actual class LocationManager {
     // -------------------------------------------------------------------------------------------
 
     var requiredPermission = LocationAuthorizationStatus.AuthorizedAlways
-    var previousAuthorizationStatus = LocationAuthorizationStatus.NotSet
+    var previousAuthorizationStatus = NativeAtomicReference(LocationAuthorizationStatus.NotSet)
 
     fun onAlwaysAllowsPermissionRequired(
         target: Any,

--- a/src/iosMain/kotlin/com/linecorp/abc/location/extension/ABCLocationExt.kt
+++ b/src/iosMain/kotlin/com/linecorp/abc/location/extension/ABCLocationExt.kt
@@ -22,5 +22,5 @@ fun ABCLocation.Companion.removeOnAlwaysAllowsPermissionRequired(target: Any) =
     locationManager.removeOnAlwaysAllowsPermissionRequired(target)
     
 internal var ABCLocation.Companion.previousAuthorizationStatus: LocationAuthorizationStatus
-    get() = locationManager.previousAuthorizationStatus
-    set(value) { locationManager.previousAuthorizationStatus = value }
+    get() = locationManager.previousAuthorizationStatus.value
+    set(value) { locationManager.previousAuthorizationStatus.value = value }


### PR DESCRIPTION
## Summary

지난 #5 PR 변경의 영향으로 아래와 Crash 가 발생하는 현상 발견

<img width="1471" alt="image" src="https://user-images.githubusercontent.com/13335632/144221623-c197f75d-5da6-408f-b46c-32726bb7dc23.png">

이슈 해결을 위해 `previousAuthorizationStatus` 변수를 NativeAtomicReference 로 변경.

