### PR TITLE
Bugfix: ThrowInvalidMutabilityException in requiredPermissions.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.cli.common.toBooleanLenient
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 val isSnapshotUpload = System.getProperty("snapshot").toBooleanLenient() ?: false
-val libVersion = "0.2.8"
+val libVersion = "0.2.9"
 val gitName = "abc-${project.name}"
 
 buildscript {

--- a/kmm_location.podspec
+++ b/kmm_location.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'kmm_location'
-    spec.version                  = '0.2.8'
+    spec.version                  = '0.2.9'
     spec.homepage                 = ''
     spec.source                   = { :git => "Not Published", :tag => "Cocoapods/#{spec.name}/#{spec.version}" }
     spec.authors                  = ''

--- a/sample/shared/build.gradle.kts
+++ b/sample/shared/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     kotlin("native.cocoapods")
 }
 
-val abcLocationLib = "com.linecorp.abc:kmm-location:0.2.8"
+val abcLocationLib = "com.linecorp.abc:kmm-location:0.2.9"
 
 version = "1.0"
 

--- a/src/iosMain/kotlin/com/linecorp/abc/location/LocationManager.kt
+++ b/src/iosMain/kotlin/com/linecorp/abc/location/LocationManager.kt
@@ -58,7 +58,7 @@ internal actual class LocationManager {
     //  Public
     // -------------------------------------------------------------------------------------------
 
-    var requiredPermission = NativeAtomicReference(LocationAuthorizationStatus.AuthorizedAlways)
+    val requiredPermission = NativeAtomicReference(LocationAuthorizationStatus.AuthorizedAlways)
     val previousAuthorizationStatus = NativeAtomicReference(LocationAuthorizationStatus.NotSet)
 
     fun onAlwaysAllowsPermissionRequired(

--- a/src/iosMain/kotlin/com/linecorp/abc/location/LocationManager.kt
+++ b/src/iosMain/kotlin/com/linecorp/abc/location/LocationManager.kt
@@ -16,7 +16,7 @@ internal actual class LocationManager {
     // -------------------------------------------------------------------------------------------
 
     actual fun isPermissionAllowed() =
-        authorizationStatus == requiredPermission
+        authorizationStatus == requiredPermission.value
 
     actual fun removeAllListeners() {
         onAlwaysAllowsPermissionRequiredBlockMap.value = emptyMap()
@@ -58,7 +58,7 @@ internal actual class LocationManager {
     //  Public
     // -------------------------------------------------------------------------------------------
 
-    var requiredPermission = LocationAuthorizationStatus.AuthorizedAlways
+    var requiredPermission = NativeAtomicReference(LocationAuthorizationStatus.AuthorizedAlways)
     val previousAuthorizationStatus = NativeAtomicReference(LocationAuthorizationStatus.NotSet)
 
     fun onAlwaysAllowsPermissionRequired(
@@ -79,7 +79,7 @@ internal actual class LocationManager {
     // -------------------------------------------------------------------------------------------
 
     private val isRequiredAllowAlways: Boolean
-        get() = requiredPermission == LocationAuthorizationStatus.AuthorizedAlways
+        get() = requiredPermission.value == LocationAuthorizationStatus.AuthorizedAlways
 
     private val authorizationStatus: LocationAuthorizationStatus
         get() = if (Version(UIDevice.currentDevice.systemVersion) >= Version("14")) {

--- a/src/iosMain/kotlin/com/linecorp/abc/location/extension/ABCLocationExt.kt
+++ b/src/iosMain/kotlin/com/linecorp/abc/location/extension/ABCLocationExt.kt
@@ -7,8 +7,8 @@ import com.linecorp.abc.location.LocationAuthorizationStatus
 typealias OnAlwaysAllowsPermissionRequiredBlock = () -> Unit
 
 var ABCLocation.Companion.requiredPermission: LocationAuthorizationStatus
-    get() = locationManager.requiredPermission
-    set(value) { locationManager.requiredPermission = value }
+    get() = locationManager.requiredPermission.value
+    set(value) { locationManager.requiredPermission.value = value }
 
 fun ABCLocation.Companion.onAlwaysAllowsPermissionRequired(
     target: Any,


### PR DESCRIPTION
PR #8 의 변경사항을 `requiredPermissions` 변수에도 동일하게 적용합니다.

`requiredPermissions` 값 변경이 있을 때 이전 피알과 동일한 Crash 가 발생하는 이유입니다.